### PR TITLE
Wrong language in order status mails

### DIFF
--- a/src/DependencyInjection/OrderServiceGeneratorPass.php
+++ b/src/DependencyInjection/OrderServiceGeneratorPass.php
@@ -79,11 +79,13 @@ class OrderServiceGeneratorPass implements CompilerPassInterface
                         continue;
                     }
 
+                    // Fetch order context to pass it into the event
+                    $orderContextStmt = new Expression(new Assign($builder->var('orderContext'), $builder->methodCall($builder->var('this'), 'getOrderContext', [$builder->var('context'), $builder->var('order')])));
                     // Fire event
-                    $arg = $builder->new('\\' . MailDataBagFilter::class, [$builder->var('data'), $builder->var('mailTemplate'), $builder->var('context')]);
+                    $arg = $builder->new('\\' . MailDataBagFilter::class, [$builder->var('data'), $builder->var('mailTemplate'), $builder->var('orderContext')]);
                     $newStmt = new Expression($builder->methodCall($propertyFetch, 'dispatch', [$arg]));
 
-                    array_splice($method->stmts, $i, 0, [$newStmt]);
+                    array_splice($method->stmts, $i, 0, [$orderContextStmt, $newStmt]);
                 }
             }
         }


### PR DESCRIPTION
Currently the language ID chain is taken from the sales channel. As there are no subshops like in SW5, the sales channel doesn't have the correct information if an order was places in a different than the default language of this sales channel.
This PR fetches the order context from the current order and passes it instead of the default context.