### PR TITLE
Load SW default templates when mjml api is unavailable

### DIFF
--- a/src/Services/MailLoader/MjmlLoader.php
+++ b/src/Services/MailLoader/MjmlLoader.php
@@ -58,9 +58,17 @@ class MjmlLoader implements LoaderInterface
 
         $compileTemplate = json_decode($response->getBody()->getContents(), true);
 
-        if (is_null($compileTemplate) || count($compileTemplate) === 0 || !empty($compileTemplate['errors'])) {
+        if (is_null($compileTemplate) || count($compileTemplate) === 0) {
             // Return empty string to load shopware default templates.
             return '';
+        }
+
+        if (!empty($compileTemplate['errors'])) {
+            foreach ($compileTemplate['errors'] as $error) {
+                $this->logger->critical('Error during compiling of MJML templates', ['response' => $error]);
+            }
+
+            throw new MjmlCompileError(implode('\n', $compileTemplate['errors']));
         }
 
         return $compileTemplate['html'];

--- a/src/Services/MailLoader/MjmlLoader.php
+++ b/src/Services/MailLoader/MjmlLoader.php
@@ -52,20 +52,15 @@ class MjmlLoader implements LoaderInterface
         } catch (ServerException $e) {
             $this->logger->critical('MJML Api is not accessible', ['response' => $e->getResponse()->getBody(), 'code' => $e->getResponse()->getStatusCode()]);
 
-            throw $e;
+            // Return empty string to load shopware default templates.
+            return '';
         }
 
         $compileTemplate = json_decode($response->getBody()->getContents(), true);
 
-        if (is_null($compileTemplate) || count($compileTemplate) === 0) {
-            // ToDo: Get default mail template contents.
+        if (is_null($compileTemplate) || count($compileTemplate) === 0 || !empty($compileTemplate['errors'])) {
+            // Return empty string to load shopware default templates.
             return '';
-        }
-
-        if (!empty($compileTemplate['errors'])) {
-            foreach ($compileTemplate['errors'] as $error) {
-                throw new MjmlCompileError($error);
-            }
         }
 
         return $compileTemplate['html'];


### PR DESCRIPTION
As mentioned in Issue #27 the SW default templates should be loaded if API is unavailable.