### PR TITLE
Add configurable MJML server

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Frosh\TemplateMail\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('frosh_platform_template_mail');
+
+        $rootNode = $treeBuilder->getRootNode();
+        $rootNode
+            ->children()
+                ->scalarNode('mjml_server')->defaultValue('https://mjml.shyim.de')->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/src/DependencyInjection/FroshPlatformTemplateMailExtension.php
+++ b/src/DependencyInjection/FroshPlatformTemplateMailExtension.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Frosh\TemplateMail\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+class FroshPlatformTemplateMailExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $config = $this->processConfiguration($this->getConfiguration($configs, $container), $configs);
+        $container->setParameter('frosh_platform_template_mail.mjml_server', $config['mjml_server']);
+    }
+}

--- a/src/FroshPlatformTemplateMail.php
+++ b/src/FroshPlatformTemplateMail.php
@@ -5,6 +5,7 @@ namespace Frosh\TemplateMail;
 use Frosh\TemplateMail\DependencyInjection\CacheCompilerPass;
 use Shopware\Core\Framework\Plugin;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 class FroshPlatformTemplateMail extends Plugin
 {

--- a/src/Resources/config/loaders.xml
+++ b/src/Resources/config/loaders.xml
@@ -11,7 +11,8 @@
 
         <service id="Frosh\TemplateMail\Services\MailLoader\MjmlLoader">
             <tag name="frosh_template_mail.loader"/>
-            <argument type="service" id="monolog.logger"/>
+            <argument key="$mjmlServer">%frosh_platform_template_mail.mjml_server%</argument>
+            <argument key="$logger" type="service" id="monolog.logger"/>
         </service>
     </services>
 </container>

--- a/src/Services/MailLoader/MjmlLoader.php
+++ b/src/Services/MailLoader/MjmlLoader.php
@@ -13,6 +13,7 @@ class MjmlLoader implements LoaderInterface
     private const MJML_INCLUDE = '/<mj-include.*?path=[\'|\"]([^"|\']*)[^>]*\/>/im';
 
     public function __construct(
+        private readonly string $mjmlServer,
         private readonly LoggerInterface $logger,
         private readonly Client $client = new Client(
         )
@@ -33,7 +34,7 @@ class MjmlLoader implements LoaderInterface
         $mjmlTemplate = $this->parseIncludes($fileContent, \dirname($path));
 
         try {
-            $response = $this->client->post('https://mjml.shyim.de', [
+            $response = $this->client->post($this->mjmlServer, [
                 'json' => [
                     'mjml' => $mjmlTemplate,
                 ],

--- a/tests/Services/MailLoader/MjmlLoaderTest.php
+++ b/tests/Services/MailLoader/MjmlLoaderTest.php
@@ -18,7 +18,7 @@ class MjmlLoaderTest extends TestCase
 {
     public function testLoadingWorks(): void
     {
-        $loader = new MjmlLoader(new NullLogger());
+        $loader = new MjmlLoader('https://mjml.shyim.de', new NullLogger());
         static::assertSame(['mjml'], $loader->supportedExtensions());
 
         $text = $loader->load(__DIR__ . '/_fixtures/test.mjml');
@@ -35,7 +35,7 @@ class MjmlLoaderTest extends TestCase
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(['handler' => $handlerStack]);
 
-        $loader = new MjmlLoader(new NullLogger(), $client);
+        $loader = new MjmlLoader('https://mjml.shyim.de', new NullLogger(), $client);
 
         static::assertSame('', $loader->load(__DIR__ . '/_fixtures/test.mjml'));
     }
@@ -49,7 +49,7 @@ class MjmlLoaderTest extends TestCase
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(['handler' => $handlerStack]);
 
-        $loader = new MjmlLoader(new NullLogger(), $client);
+        $loader = new MjmlLoader('https://mjml.shyim.de', new NullLogger(), $client);
 
         static::expectException(MjmlCompileError::class);
         $loader->load(__DIR__ . '/_fixtures/test.mjml');


### PR DESCRIPTION
Fixes #54

I tried using `frosh_template_mail` instead of `frosh_platform_template_mail` for the config key, but that didn't seem to work since the plugin is called FroshPlatform. If I'm doing something wrong for that, let me know.

I based it of FroshTools, but didn't create the some custom things that can also be automatic (default values, configuration class loader, extension class loader).

I did use the existing `services.xml` and not autowiring since the rest of the project does the same.