### PR TITLE
feat: add debug info to subject

### DIFF
--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/master/src/Core/System/SystemConfig/Schema/config.xsd">
+    <card>
+        <title>Debug mode</title>
+        <title lang="de-DE">Debug-Modus</title>
+
+        <input-field type="bool">
+            <name>debugMode</name>
+            <label>Enable debug mode</label>
+            <label lang="de-DE">Debug-Modus aktivieren</label>
+            <helpText>Adds the technical name of the mail-template to the subject to easily identify which mail has been send</helpText>
+            <helpText lang="de-DE">Fügt den technischen Namen der Mail-Vorlage zum Betreff hinzu, um leicht zu erkennen, welche Mail gesendet wurde</helpText>
+        </input-field>
+    </card>
+</config>

--- a/src/Subscriber/FlowSubscriber.php
+++ b/src/Subscriber/FlowSubscriber.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
 use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Language\LanguageEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -30,7 +31,7 @@ class FlowSubscriber implements EventSubscriberInterface
     /**
      * @param EntityRepository<MailTemplateTypeCollection> $mailTemplateTypeRepository
      * @param EntityRepository<LanguageCollection> $languageRepository
-     * @param EntityRepository<SalesChannelEntity> $salesChannelRepository
+     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
      */
     public function __construct(
         private readonly EntityRepository $mailTemplateTypeRepository,
@@ -82,7 +83,7 @@ class FlowSubscriber implements EventSubscriberInterface
         }
 
         if ($subject) {
-            $salesChannelId = $dataBag->get('salesChannelId');
+            $salesChannelId = $dataBag->getString('salesChannelId');
             $debugMode = $this->systemConfigService->getBool('FroshPlatformTemplateMail.config.debugMode', $salesChannelId);
             if ($debugMode) {
                 $subject = sprintf(
@@ -90,7 +91,7 @@ class FlowSubscriber implements EventSubscriberInterface
                     $subject,
                     $this->getSalesChannelName($salesChannelId, $context),
                     $this->getLocaleCode($context->getLanguageId(), $context),
-                    $technicalName
+                    $technicalName,
                 );
             }
             $dataBag->set('subject', $subject);
@@ -111,7 +112,7 @@ class FlowSubscriber implements EventSubscriberInterface
     {
         $localCode = $this->getLocaleCode(
             $businessEvent->getContext()->getLanguageId(),
-            $businessEvent->getContext()
+            $businessEvent->getContext(),
         );
 
         if ($localCode === null) {

--- a/src/Subscriber/FlowSubscriber.php
+++ b/src/Subscriber/FlowSubscriber.php
@@ -19,6 +19,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
 use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Language\LanguageEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -28,6 +30,7 @@ class FlowSubscriber implements EventSubscriberInterface
     /**
      * @param EntityRepository<MailTemplateTypeCollection> $mailTemplateTypeRepository
      * @param EntityRepository<LanguageCollection> $languageRepository
+     * @param EntityRepository<SalesChannelEntity> $salesChannelRepository
      */
     public function __construct(
         private readonly EntityRepository $mailTemplateTypeRepository,
@@ -35,6 +38,8 @@ class FlowSubscriber implements EventSubscriberInterface
         #[Autowire(service: Translator::class)]
         private readonly AbstractTranslator $translator,
         private readonly EntityRepository $languageRepository,
+        private readonly SystemConfigService $systemConfigService,
+        private readonly EntityRepository $salesChannelRepository,
     ) {}
 
     public static function getSubscribedEvents(): array
@@ -77,6 +82,17 @@ class FlowSubscriber implements EventSubscriberInterface
         }
 
         if ($subject) {
+            $salesChannelId = $dataBag->get('salesChannelId');
+            $debugMode = $this->systemConfigService->getBool('FroshPlatformTemplateMail.config.debugMode', $salesChannelId);
+            if ($debugMode) {
+                $subject = sprintf(
+                    'DEBUG: %s (%s - %s - %s)',
+                    $subject,
+                    $this->getSalesChannelName($salesChannelId, $context),
+                    $this->getLocaleCode($context->getLanguageId(), $context),
+                    $technicalName
+                );
+            }
             $dataBag->set('subject', $subject);
         }
     }
@@ -93,13 +109,11 @@ class FlowSubscriber implements EventSubscriberInterface
 
     private function fixTranslator(TemplateMailContext $businessEvent): void
     {
-        $criteria = new Criteria([$businessEvent->getContext()->getLanguageId()]);
-        $criteria->addAssociation('locale');
+        $localCode = $this->getLocaleCode(
+            $businessEvent->getContext()->getLanguageId(),
+            $businessEvent->getContext()
+        );
 
-        /** @var LanguageEntity $language */
-        $language = $this->languageRepository->search($criteria, $businessEvent->getContext())->first();
-
-        $localCode = $language->getLocale()?->getCode();
         if ($localCode === null) {
             return;
         }
@@ -110,5 +124,26 @@ class FlowSubscriber implements EventSubscriberInterface
             $localCode,
             $businessEvent->getContext(),
         );
+    }
+
+    private function getLocaleCode(string $languageId, Context $context): ?string
+    {
+        $criteria = new Criteria([$languageId]);
+        $criteria->addAssociation('locale');
+
+        /** @var LanguageEntity $language */
+        $language = $this->languageRepository->search($criteria, $context)->first();
+
+        return $language->getLocale()?->getCode();
+    }
+
+    private function getSalesChannelName(string $salesChannelId, Context $context): ?string
+    {
+        $criteria = new Criteria([$salesChannelId]);
+
+        /** @var SalesChannelEntity $salesChannel */
+        $salesChannel = $this->salesChannelRepository->search($criteria, $context)->first();
+
+        return $salesChannel->getName();
     }
 }

--- a/tests/Subscriber/FlowSubscriberTest.php
+++ b/tests/Subscriber/FlowSubscriberTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 class FlowSubscriberTest extends TestCase
 {
@@ -33,6 +34,8 @@ class FlowSubscriberTest extends TestCase
             $mailTemplateTypeRepository,
             $this->createMock(MailFinderServiceInterface::class),
             $this->createMock(AbstractTranslator::class),
+            $this->createMock(EntityRepository::class),
+            $this->createMock(SystemConfigService::class),
             $this->createMock(EntityRepository::class),
         );
 


### PR DESCRIPTION
Adds relevant debug information to the subject to easily determine which exact mail has been send.

![image](https://github.com/FriendsOfShopware/FroshPlatformTemplateMail/assets/26538915/28d21522-55be-4132-93f6-ef15a1a1df6c)
