### PR TITLE
Fix convert error and use saleschannel name translation

### DIFF
--- a/src/Subscriber/FlowSubscriber.php
+++ b/src/Subscriber/FlowSubscriber.php
@@ -83,6 +83,7 @@ class FlowSubscriber implements EventSubscriberInterface
         }
 
         if ($subject) {
+            /** @var string|null $salesChannelId */
             $salesChannelId = $dataBag->get('salesChannelId');
             $debugMode = $this->systemConfigService->getBool('FroshPlatformTemplateMail.config.debugMode', $salesChannelId);
 
@@ -155,6 +156,6 @@ class FlowSubscriber implements EventSubscriberInterface
         /** @var SalesChannelEntity $salesChannel */
         $salesChannel = $this->salesChannelRepository->search($criteria, $context)->first();
 
-        return $salesChannel->getTranslation('name');
+        return (string) $salesChannel->getTranslation('name');
     }
 }

--- a/src/Subscriber/FlowSubscriber.php
+++ b/src/Subscriber/FlowSubscriber.php
@@ -83,13 +83,19 @@ class FlowSubscriber implements EventSubscriberInterface
         }
 
         if ($subject) {
-            $salesChannelId = $dataBag->getString('salesChannelId');
+            $salesChannelId = $dataBag->get('salesChannelId');
             $debugMode = $this->systemConfigService->getBool('FroshPlatformTemplateMail.config.debugMode', $salesChannelId);
+
+            $salesChannelName = 'Administration';
+            if ($salesChannelId) {
+                $salesChannelName = $this->getSalesChannelName($salesChannelId, $context);
+            }
+
             if ($debugMode) {
                 $subject = sprintf(
                     'DEBUG: %s (%s - %s - %s)',
                     $subject,
-                    $this->getSalesChannelName($salesChannelId, $context),
+                    $salesChannelName,
                     $this->getLocaleCode($context->getLanguageId(), $context),
                     $technicalName,
                 );
@@ -149,6 +155,6 @@ class FlowSubscriber implements EventSubscriberInterface
         /** @var SalesChannelEntity $salesChannel */
         $salesChannel = $this->salesChannelRepository->search($criteria, $context)->first();
 
-        return $salesChannel->getName();
+        return $salesChannel->getTranslation('name');
     }
 }


### PR DESCRIPTION
- Fix https://github.com/FriendsOfShopware/FroshPlatformTemplateMail/issues/70, use 'Administration' as fallback name when no salesChannelId is present in the dataBag
- Use `getTranslation('name')` for retrieving salesChannel name