### PR TITLE
Make it compatible with MailTemplateEntity

### DIFF
--- a/src/Subscriber/MailTemplateSubscriber.php
+++ b/src/Subscriber/MailTemplateSubscriber.php
@@ -71,6 +71,10 @@ class MailTemplateSubscriber implements EventSubscriberInterface
             $plain = $this->mailFinderService->findTemplateByTechnicalName(MailFinderService::TYPE_PLAIN, $technicalName, $businessEvent, true, $mailTemplateEntity->getId());
             $subject = $this->mailFinderService->findTemplateByTechnicalName(MailFinderService::TYPE_SUBJECT, $technicalName, $businessEvent, true, $mailTemplateEntity->getId());
 
+            $mailTemplateEntity->addTranslated('subject', file_get_contents($subject));
+            $mailTemplateEntity->addTranslated('contentHtml', file_get_contents($html));
+            $mailTemplateEntity->addTranslated('contentPlain', file_get_contents($plain));
+
             $mailTemplateEntity->addExtension(
                 'froshTemplateMail',
                 new ArrayStruct([


### PR DESCRIPTION
We are using SendMailTemplateParams and SendMailTemplate to send mails and this extension is currently not compatible with it, so my colleague Bruno added some magic.

If you can think of a better way, please tell us, currently we overwrite the translations with the templates from the disk. We hoped to use BeforeMailValidate, but this is already too late to inject the data.