### PR TITLE
feat: use filesystem templates for test emails sent from admin

### DIFF
--- a/src/Subscriber/MailBeforeValidateSubscriber.php
+++ b/src/Subscriber/MailBeforeValidateSubscriber.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\TemplateMail\Subscriber;
+
+use Frosh\TemplateMail\Services\MailFinderServiceInterface;
+use Frosh\TemplateMail\Services\TemplateMailContext;
+use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateType\MailTemplateTypeCollection;
+use Shopware\Core\Content\MailTemplate\Service\Event\MailBeforeValidateEvent;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class MailBeforeValidateSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @param EntityRepository<MailTemplateTypeCollection> $mailTemplateTypeRepository
+     */
+    public function __construct(
+        private readonly EntityRepository $mailTemplateTypeRepository,
+        private readonly MailFinderServiceInterface $mailFinderService,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            MailBeforeValidateEvent::class => 'onMailBeforeValidate',
+        ];
+    }
+
+    public function onMailBeforeValidate(MailBeforeValidateEvent $event): void
+    {
+        $data = $event->getData();
+
+        $mailTemplateTypeId = $data['mailTemplateTypeId'] ?? null;
+        if (!\is_string($mailTemplateTypeId)) {
+            return;
+        }
+
+        $technicalName = $this->getTechnicalName($mailTemplateTypeId, $event->getContext());
+
+        $salesChannelId = $data['salesChannelId'] ?? Defaults::SALES_CHANNEL_TYPE_STOREFRONT;
+        $mailTemplateId = $data['mailTemplateId'] ?? null;
+
+        $templateMailContext = new TemplateMailContext(
+            \is_string($salesChannelId) ? $salesChannelId : Defaults::SALES_CHANNEL_TYPE_STOREFRONT,
+            $event->getContext(),
+        );
+
+        $templateData = $this->mailFinderService->getTemplateDataByTechnicalName(
+            $technicalName,
+            $templateMailContext,
+            \is_string($mailTemplateId) ? $mailTemplateId : null,
+        );
+
+        if ($templateData->html !== null) {
+            $data['contentHtml'] = $templateData->html->content;
+        }
+
+        if ($templateData->plain !== null) {
+            $data['contentPlain'] = $templateData->plain->content;
+        }
+
+        if ($templateData->subject !== null) {
+            $data['subject'] = $templateData->subject->content;
+        }
+
+        $event->setData($data);
+    }
+
+    private function getTechnicalName(string $mailTemplateTypeId, Context $context): string
+    {
+        $criteria = new Criteria([$mailTemplateTypeId]);
+        $criteria->addFields(['technicalName']);
+
+        /** @var PartialEntity|null $mailTemplateType */
+        $mailTemplateType = $this->mailTemplateTypeRepository->search($criteria, $context)->first();
+
+        $technicalName = $mailTemplateType?->get('technicalName');
+
+        if (!\is_string($technicalName)) {
+            throw new \RuntimeException('technicalName could not be determined');
+        }
+
+        return $technicalName;
+    }
+}


### PR DESCRIPTION
## Summary

- Subscribes to `MailBeforeValidateEvent` to replace database templates with filesystem templates when sending test emails from **Admin > Settings > Email Templates**
- Since Shopware 6.6.7.0 ([shopware/shopware#4850](https://github.com/shopware/shopware/pull/4850)), the admin includes `mailTemplateTypeId` and `mailTemplateId` in the test email API payload — this subscriber uses those to resolve the correct filesystem template
- No changes to `services.xml` needed — autoconfigure picks up the new subscriber automatically

## How it works

The new `MailBeforeValidateSubscriber`:
1. Checks if `mailTemplateTypeId` is present in the event data (early return if not)
2. Resolves the technical name from `mailTemplateTypeId`
3. Uses the existing `MailFinderService` to find filesystem templates
4. Replaces `contentHtml`, `contentPlain`, and `subject` in the event data

This complements the existing `FlowSubscriber` (which handles flow-based emails) by covering the `MailService::send()` path used by the admin test email feature.

## Test plan

- [ ] Clear cache
- [ ] Go to Admin > Settings > Email Templates
- [ ] Select a template that has a filesystem override (e.g. order confirmation)
- [ ] Click "Send test email", choose a sales channel, enter a recipient
- [ ] Verify the received email uses the filesystem template content, not the database content

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)