### PR TITLE
feat: add local MJML renderer using spatie/mjml-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         }
     },
     "require": {
-        "shopware/core": "~6.5.8 || ~6.6.0 || ~6.7.0"
+        "shopware/core": "~6.5.8 || ~6.6.0 || ~6.7.0",
+        "spatie/mjml-php": "^1.0"
     },
     "scripts": {
         "format": "docker run --rm -v $(pwd):/ext shopware/shopware-cli:latest extension format /ext",

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -15,6 +15,10 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('mjml_server')->defaultValue('https://mjml.shyim.de')->end()
+                ->enumNode('mjml_renderer')
+                    ->values(['api', 'local'])
+                    ->defaultValue('api')
+                ->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/FroshPlatformTemplateMailExtension.php
+++ b/src/DependencyInjection/FroshPlatformTemplateMailExtension.php
@@ -2,6 +2,9 @@
 
 namespace Frosh\TemplateMail\DependencyInjection;
 
+use Frosh\TemplateMail\Services\MjmlRenderer\ApiMjmlRenderer;
+use Frosh\TemplateMail\Services\MjmlRenderer\LocalMjmlRenderer;
+use Frosh\TemplateMail\Services\MjmlRenderer\MjmlRendererInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 
@@ -11,8 +14,15 @@ class FroshPlatformTemplateMailExtension extends Extension
     {
         $configuration = $this->getConfiguration($configs, $container);
         \assert($configuration instanceof Configuration);
-        /** @var array{mjml_server: string} $config */
+        /** @var array{mjml_server: string, mjml_renderer: string} $config */
         $config = $this->processConfiguration($configuration, $configs);
         $container->setParameter('frosh_platform_template_mail.mjml_server', $config['mjml_server']);
+
+        $rendererClass = match ($config['mjml_renderer']) {
+            'local' => LocalMjmlRenderer::class,
+            default => ApiMjmlRenderer::class,
+        };
+
+        $container->setAlias(MjmlRendererInterface::class, $rendererClass);
     }
 }

--- a/src/FroshPlatformTemplateMail.php
+++ b/src/FroshPlatformTemplateMail.php
@@ -8,4 +8,8 @@ use Shopware\Core\Framework\Plugin;
 
 class FroshPlatformTemplateMail extends Plugin
 {
+    public function executeComposerCommands(): bool
+    {
+        return true;
+    }
 }

--- a/src/Services/MailLoader/MjmlLoader.php
+++ b/src/Services/MailLoader/MjmlLoader.php
@@ -5,29 +5,23 @@ declare(strict_types=1);
 namespace Frosh\TemplateMail\Services\MailLoader;
 
 use Frosh\TemplateMail\Exception\MjmlCompileError;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\ServerException;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Frosh\TemplateMail\Services\MjmlRenderer\MjmlRendererInterface;
 
 class MjmlLoader implements LoaderInterface
 {
     private const MJML_INCLUDE = '/<mj-include.*?path=[\'|\"]([^"|\']*)[^>]*\/>/im';
 
     public function __construct(
-        #[Autowire('%frosh_platform_template_mail.mjml_server%')]
-        private readonly string $mjmlServer,
-        private readonly LoggerInterface $logger,
-        private readonly Client $client = new Client(),
+        private readonly MjmlRendererInterface $mjmlRenderer,
     ) {
     }
 
-    /**
-     * @throws GuzzleException
-     */
     public function load(string $path): string
     {
+        if (!file_exists($path)) {
+            return '';
+        }
+
         $fileContent = file_get_contents($path);
         if ($fileContent === false) {
             // Return empty string to load shopware default templates.
@@ -36,36 +30,7 @@ class MjmlLoader implements LoaderInterface
 
         $mjmlTemplate = $this->parseIncludes($fileContent, \dirname($path));
 
-        try {
-            $response = $this->client->post($this->mjmlServer, [
-                'json' => [
-                    'mjml' => $mjmlTemplate,
-                ],
-            ]);
-        } catch (ServerException $e) {
-            $this->logger->critical('MJML Api is not accessible', ['response' => $e->getResponse()->getBody(), 'code' => $e->getResponse()->getStatusCode()]);
-
-            // Return empty string to load shopware default templates.
-            return '';
-        }
-
-        /** @var array{errors?: array<string>, html?: string}|string $compileTemplate */
-        $compileTemplate = json_decode($response->getBody()->getContents(), true, 512, \JSON_THROW_ON_ERROR);
-
-        if (empty($compileTemplate) || !\is_array($compileTemplate)) {
-            // Return empty string to load shopware default templates.
-            return '';
-        }
-
-        if (\array_key_exists('errors', $compileTemplate) && !empty($compileTemplate['errors'])) {
-            foreach ($compileTemplate['errors'] as $error) {
-                $this->logger->critical('Error during compiling of MJML templates', ['response' => $error]);
-            }
-
-            throw new MjmlCompileError(implode('\n', $compileTemplate['errors']));
-        }
-
-        return $compileTemplate['html'];
+        return $this->mjmlRenderer->render($mjmlTemplate);
     }
 
     /**

--- a/src/Services/MjmlRenderer/ApiMjmlRenderer.php
+++ b/src/Services/MjmlRenderer/ApiMjmlRenderer.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\TemplateMail\Services\MjmlRenderer;
+
+use Frosh\TemplateMail\Exception\MjmlCompileError;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\ServerException;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+class ApiMjmlRenderer implements MjmlRendererInterface
+{
+    public function __construct(
+        #[Autowire('%frosh_platform_template_mail.mjml_server%')]
+        private readonly string $mjmlServer,
+        private readonly LoggerInterface $logger,
+        private readonly Client $client = new Client(),
+    ) {
+    }
+
+    /**
+     * @throws GuzzleException
+     */
+    public function render(string $mjml): string
+    {
+        try {
+            $response = $this->client->post($this->mjmlServer, [
+                'json' => [
+                    'mjml' => $mjml,
+                ],
+            ]);
+        } catch (ServerException $e) {
+            $this->logger->critical('MJML Api is not accessible', ['response' => $e->getResponse()->getBody(), 'code' => $e->getResponse()->getStatusCode()]);
+
+            // Return empty string to load shopware default templates.
+            return '';
+        }
+
+        /** @var array{errors?: array<string>, html?: string}|string $compileTemplate */
+        $compileTemplate = json_decode($response->getBody()->getContents(), true, 512, \JSON_THROW_ON_ERROR);
+
+        if (empty($compileTemplate) || !\is_array($compileTemplate)) {
+            // Return empty string to load shopware default templates.
+            return '';
+        }
+
+        if (\array_key_exists('errors', $compileTemplate) && !empty($compileTemplate['errors'])) {
+            foreach ($compileTemplate['errors'] as $error) {
+                $this->logger->critical('Error during compiling of MJML templates', ['response' => $error]);
+            }
+
+            throw new MjmlCompileError(implode('\n', $compileTemplate['errors']));
+        }
+
+        return $compileTemplate['html'];
+    }
+}

--- a/src/Services/MjmlRenderer/LocalMjmlRenderer.php
+++ b/src/Services/MjmlRenderer/LocalMjmlRenderer.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\TemplateMail\Services\MjmlRenderer;
+
+use Frosh\TemplateMail\Exception\MjmlCompileError;
+use Psr\Log\LoggerInterface;
+use Spatie\Mjml\Mjml;
+use Spatie\Mjml\MjmlError;
+
+class LocalMjmlRenderer implements MjmlRendererInterface
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function render(string $mjml): string
+    {
+        try {
+            $result = Mjml::new()->convert($mjml);
+        } catch (\Exception $e) {
+            $this->logger->critical('Local MJML rendering failed', ['error' => $e->getMessage()]);
+
+            // Return empty string to load shopware default templates.
+            return '';
+        }
+
+        if ($result->hasErrors()) {
+            foreach ($result->errors() as $error) {
+                $this->logger->critical('Error during local MJML compilation', ['error' => $error->formattedMessage()]);
+            }
+
+            throw new MjmlCompileError(implode("\n", array_map(
+                static fn (MjmlError $error): string => $error->formattedMessage(),
+                $result->errors()
+            )));
+        }
+
+        return $result->html();
+    }
+}

--- a/src/Services/MjmlRenderer/MjmlRendererInterface.php
+++ b/src/Services/MjmlRenderer/MjmlRendererInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\TemplateMail\Services\MjmlRenderer;
+
+interface MjmlRendererInterface
+{
+    /**
+     * Convert assembled MJML (includes already resolved) to HTML.
+     *
+     * @throws \Frosh\TemplateMail\Exception\MjmlCompileError
+     */
+    public function render(string $mjml): string;
+}

--- a/tests/Services/MailLoader/MjmlLoaderTest.php
+++ b/tests/Services/MailLoader/MjmlLoaderTest.php
@@ -6,53 +6,61 @@ namespace Frosh\TemplateMail\Tests\Services\MailLoader;
 
 use Frosh\TemplateMail\Exception\MjmlCompileError;
 use Frosh\TemplateMail\Services\MailLoader\MjmlLoader;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ServerException;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Response;
+use Frosh\TemplateMail\Services\MjmlRenderer\MjmlRendererInterface;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\NullLogger;
 
 class MjmlLoaderTest extends TestCase
 {
-    public function testLoadingWorks(): void
+    public function testSupportedExtensions(): void
     {
-        $loader = new MjmlLoader('https://mjml.shyim.de', new NullLogger());
+        $renderer = $this->createMock(MjmlRendererInterface::class);
+        $loader = new MjmlLoader($renderer);
+
         static::assertSame(['mjml'], $loader->supportedExtensions());
-
-        $text = $loader->load(__DIR__ . '/_fixtures/test.mjml');
-        static::assertStringContainsString('<!doctype html>', $text);
-        static::assertStringContainsString('<tbody>', $text);
     }
 
-    public function testApiIsNotAvailable(): void
+    public function testLoadDelegatesToRenderer(): void
     {
-        $mock = new MockHandler([
-            new ServerException('Error Communicating with Server', new Request('GET', 'test'), new Response(500)),
-        ]);
+        $renderer = $this->createMock(MjmlRendererInterface::class);
+        $renderer->expects(static::once())
+            ->method('render')
+            ->with(static::stringContains('<mjml>'))
+            ->willReturn('<html>rendered</html>');
 
-        $handlerStack = HandlerStack::create($mock);
-        $client = new Client(['handler' => $handlerStack]);
+        $loader = new MjmlLoader($renderer);
+        $result = $loader->load(__DIR__ . '/_fixtures/test.mjml');
 
-        $loader = new MjmlLoader('https://mjml.shyim.de', new NullLogger(), $client);
-
-        static::assertSame('', $loader->load(__DIR__ . '/_fixtures/test.mjml'));
+        static::assertSame('<html>rendered</html>', $result);
     }
 
-    public function testApiRespondsErrors(): void
+    public function testLoadReturnsEmptyStringForNonExistentFile(): void
     {
-        $mock = new MockHandler([
-            new Response(200, ['Content-Type' => 'application/json'], json_encode(['errors' => ['some error happend']], JSON_THROW_ON_ERROR)),
-        ]);
+        $renderer = $this->createMock(MjmlRendererInterface::class);
+        $renderer->expects(static::never())->method('render');
 
-        $handlerStack = HandlerStack::create($mock);
-        $client = new Client(['handler' => $handlerStack]);
+        $loader = new MjmlLoader($renderer);
+        $result = $loader->load(__DIR__ . '/_fixtures/nonexistent.mjml');
 
-        $loader = new MjmlLoader('https://mjml.shyim.de', new NullLogger(), $client);
+        static::assertSame('', $result);
+    }
+
+    public function testLoadThrowsOnMissingInclude(): void
+    {
+        $renderer = $this->createMock(MjmlRendererInterface::class);
+        $loader = new MjmlLoader($renderer);
+
+        // Create a temp file with an include that doesn't exist
+        $tempDir = sys_get_temp_dir() . '/mjml_test_' . uniqid();
+        mkdir($tempDir);
+        file_put_contents($tempDir . '/test.mjml', '<mjml><mj-body><mj-include path="missing.mjml" /></mj-body></mjml>');
 
         static::expectException(MjmlCompileError::class);
-        $loader->load(__DIR__ . '/_fixtures/test.mjml');
+
+        try {
+            $loader->load($tempDir . '/test.mjml');
+        } finally {
+            unlink($tempDir . '/test.mjml');
+            rmdir($tempDir);
+        }
     }
 }

--- a/tests/Services/MjmlRenderer/ApiMjmlRendererTest.php
+++ b/tests/Services/MjmlRenderer/ApiMjmlRendererTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\TemplateMail\Tests\Services\MjmlRenderer;
+
+use Frosh\TemplateMail\Exception\MjmlCompileError;
+use Frosh\TemplateMail\Services\MjmlRenderer\ApiMjmlRenderer;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class ApiMjmlRendererTest extends TestCase
+{
+    public function testRenderingWorks(): void
+    {
+        $renderer = new ApiMjmlRenderer('https://mjml.shyim.de', new NullLogger());
+
+        $mjml = file_get_contents(__DIR__ . '/../MailLoader/_fixtures/test.mjml');
+        static::assertIsString($mjml);
+
+        $html = $renderer->render($mjml);
+        static::assertStringContainsString('<!doctype html>', $html);
+        static::assertStringContainsString('<tbody>', $html);
+    }
+
+    public function testApiIsNotAvailable(): void
+    {
+        $mock = new MockHandler([
+            new ServerException('Error Communicating with Server', new Request('GET', 'test'), new Response(500)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $renderer = new ApiMjmlRenderer('https://mjml.shyim.de', new NullLogger(), $client);
+
+        static::assertSame('', $renderer->render('<mjml><mj-body></mj-body></mjml>'));
+    }
+
+    public function testApiRespondsErrors(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['errors' => ['some error happend']], JSON_THROW_ON_ERROR)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $renderer = new ApiMjmlRenderer('https://mjml.shyim.de', new NullLogger(), $client);
+
+        static::expectException(MjmlCompileError::class);
+        $renderer->render('<mjml><mj-body></mj-body></mjml>');
+    }
+
+    public function testEmptyResponseReturnsEmptyString(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], '""'),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $renderer = new ApiMjmlRenderer('https://mjml.shyim.de', new NullLogger(), $client);
+
+        static::assertSame('', $renderer->render('<mjml><mj-body></mj-body></mjml>'));
+    }
+}

--- a/tests/Services/MjmlRenderer/LocalMjmlRendererTest.php
+++ b/tests/Services/MjmlRenderer/LocalMjmlRendererTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\TemplateMail\Tests\Services\MjmlRenderer;
+
+use Frosh\TemplateMail\Services\MjmlRenderer\LocalMjmlRenderer;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class LocalMjmlRendererTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(\Spatie\Mjml\Mjml::class)) {
+            static::markTestSkipped('spatie/mjml-php is not installed');
+        }
+    }
+
+    public function testRenderingWorks(): void
+    {
+        $renderer = new LocalMjmlRenderer(new NullLogger());
+
+        $mjml = file_get_contents(__DIR__ . '/../MailLoader/_fixtures/test.mjml');
+        static::assertIsString($mjml);
+
+        $html = $renderer->render($mjml);
+        static::assertStringContainsString('<!doctype html>', $html);
+        static::assertStringContainsString('Hello World', $html);
+    }
+
+    public function testInvalidMjmlReturnsEmptyString(): void
+    {
+        $renderer = new LocalMjmlRenderer(new NullLogger());
+
+        $result = $renderer->render('this is not valid mjml at all');
+
+        static::assertSame('', $result);
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts MJML rendering into a strategy pattern (`MjmlRendererInterface`) so the rendering backend is swappable
- Adds `LocalMjmlRenderer` using [spatie/mjml-php](https://github.com/spatie/mjml-php) for local Node.js-based MJML compilation
- Existing shyim.de API renderer (`ApiMjmlRenderer`) remains the default — fully backwards compatible
- Configurable via bundle config: `mjml_renderer: local` to opt-in to local rendering

## Configuration
```yaml
# config/packages/frosh_platform_template_mail.yaml
frosh_platform_template_mail:
    mjml_renderer: local  # default: api
```

Requires Node.js 16+ and the `mjml` npm package when using `local` mode.

## Test plan
- [x] Existing API renderer tests pass (migrated to `ApiMjmlRendererTest`)
- [x] New `LocalMjmlRendererTest` passes with spatie/mjml-php
- [x] `MjmlLoaderTest` updated to test file reading and include parsing independently
- [x] Tested end-to-end: switched to `local` mode, triggered mail send, verified HTML output in Mailpit
- [x] Verified `api` mode (default) still works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)